### PR TITLE
Add write_output utility

### DIFF
--- a/R/write_output.R
+++ b/R/write_output.R
@@ -1,0 +1,81 @@
+#' Export mHM outputs by time step
+#'
+#' Reads `mHM_Fluxes_States.nc` located in the `OUT` folder of a domain and
+#' writes the selected variable either as monthly or yearly layers. Results are
+#' saved inside `OUT/<var_name>` in the chosen format.
+#'
+#' @param domain_path Path to the model domain containing the `OUT` folder.
+#' @param var_name Name of the variable inside `mHM_Fluxes_States.nc` to export.
+#' @param ts Time step of the output. Either "month" or "year".
+#' @param roi_mask Logical. Apply the ROI mask to the output.
+#' @param roi_file Optional path to a ROI file. Used when `roi_mask` is `TRUE`.
+#'   If `NULL`, the `roi_file` defined in `preprocess_config.json` is used.
+#' @param out.format Output format: "tif" for GeoTIFF or "nc" for NetCDF.
+#'
+#' @return Invisibly returns the paths of the written files.
+#' @examples
+#' write_output("/path/to/domain", "Q", "year")
+#' @export
+write_output <- function(domain_path, var_name, ts,
+                         roi_mask = TRUE, roi_file = NULL,
+                         out.format = c("tif", "nc")) {
+  library(terra)
+  library(jsonlite)
+
+  out.format <- match.arg(out.format)
+  ts <- match.arg(tolower(ts), c("month", "year"))
+
+  nc_path <- file.path(domain_path, "OUT", "mHM_Fluxes_States.nc")
+  if (!file.exists(nc_path)) {
+    stop("NetCDF not found: ", nc_path)
+  }
+
+  r <- rast(nc_path, subds = var_name)
+
+  if (roi_mask) {
+    if (is.null(roi_file)) {
+      config_path <- file.path(domain_path, "preprocess_config.json")
+      if (!file.exists(config_path)) {
+        stop("Configuration file not found: ", config_path)
+      }
+      config <- fromJSON(config_path)
+      roi_file <- config$roi_file
+    }
+    if (!file.exists(roi_file)) {
+      stop("ROI file not found: ", roi_file)
+    }
+    roi <- vect(roi_file)
+    r <- mask(r, roi)
+  }
+
+  if (ts == "month") {
+    idx <- format(time(r), "%Y-%m")
+    r <- tapp(r, idx, fun = mean, na.rm = TRUE)
+    time(r) <- as.Date(paste0(unique(idx), "-01"))
+  } else if (ts == "year") {
+    idx <- format(time(r), "%Y")
+    r <- tapp(r, idx, fun = mean, na.rm = TRUE)
+    time(r) <- as.Date(paste0(unique(idx), "-01-01"))
+  }
+
+  out_dir <- file.path(domain_path, "OUT", var_name)
+  dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+
+  if (out.format == "tif") {
+    paths <- vector("character", nlyr(r))
+    for (i in seq_len(nlyr(r))) {
+      suffix <- if (ts == "month") "%Y_%m" else "%Y"
+      dstr <- format(time(r)[i], suffix)
+      fname <- file.path(out_dir, paste0(var_name, "_", dstr, ".tif"))
+      writeRaster(r[[i]], fname, overwrite = TRUE)
+      paths[i] <- fname
+    }
+  } else {
+    fname <- file.path(out_dir, paste0(var_name, ".nc"))
+    writeCDF(r, filename = fname, varname = var_name, overwrite = TRUE)
+    paths <- fname
+  }
+
+  invisible(paths)
+}
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Para una explicación detallada de cómo ejecutar el script principal de preproc
 
 Para visualizar promedios anuales de las salidas y forzantes del modelo se incluye el script [`R/visualize_annual_outputs.R`](R/visualize_annual_outputs.R).  Las funciones auxiliares `annual_mean`, `daily_to_monthly` y `monthly_to_yearly` se encuentran en [`R/utils.R`](R/utils.R). `visualize_annual_outputs` puede opcionalmente enmascarar los resultados usando el `roi_file` definido en el archivo de configuración.
 Para visualizar promedios anuales de las salidas y forzantes del modelo se incluye el script [`R/visualize_annual_outputs.R`](R/visualize_annual_outputs.R) que provee las funciones `annual_mean` y `visualize_annual_outputs`.
+La función `write_output` permite exportar variables mensuales o anuales a TIFF o NetCDF desde `mHM_Fluxes_States.nc`.


### PR DESCRIPTION
## Summary
- add an R helper `write_output` for exporting outputs from `mHM_Fluxes_States.nc`
- mention the new helper in README

## Testing
- `R` command not available so no tests run

------
https://chatgpt.com/codex/tasks/task_e_68474872f8f0832ca415fa216317ba16