### PR TITLE
Add mosaic visualization utilities

### DIFF
--- a/R/visualize_mosaic_outputs.R
+++ b/R/visualize_mosaic_outputs.R
@@ -1,0 +1,79 @@
+#' Load annual mean from mosaicked outputs
+#'
+#' Reads NetCDF files produced by `mosaic_outputs()` and returns the long term
+#' annual mean for each variable. If a region of interest (ROI) is provided,
+#' results are masked to that area.
+#'
+#' @param out_dir Directory containing the mosaicked NetCDF files.
+#' @param vars Character vector of variables to load. When `NULL`, all `.nc`
+#'   files in `out_dir` are used.
+#' @param roi_file Optional path to a ROI file used to mask the outputs.
+#' @return A named list of [`terra::SpatRaster`] objects with the annual mean of
+#'   each variable.
+#' @export
+load_mosaic_annual_means <- function(out_dir, vars = NULL, roi_file = NULL) {
+  library(terra)
+
+  if (!dir.exists(out_dir)) {
+    stop("Directory not found: ", out_dir)
+  }
+
+  if (is.null(vars)) {
+    files <- list.files(out_dir, pattern = "\\.nc$", full.names = FALSE)
+    vars <- sub("\\.nc$", "", files)
+  }
+
+  roi <- NULL
+  if (!is.null(roi_file)) {
+    if (!file.exists(roi_file)) {
+      stop("ROI file not found: ", roi_file)
+    }
+    roi <- vect(roi_file)
+  }
+
+  out <- vector("list", length(vars))
+  names(out) <- vars
+
+  for (v in vars) {
+    nc_file <- file.path(out_dir, paste0(v, ".nc"))
+    if (!file.exists(nc_file)) {
+      stop("NetCDF not found: ", nc_file)
+    }
+    r <- rast(nc_file)
+    fun <- if (v %in% c("aET", "Q", "pre", "pet")) "sum" else "mean"
+    ann <- annual_mean(r, fun)
+    if (!is.null(roi)) {
+      ann <- mask(ann, roi)
+    }
+    out[[v]] <- ann
+  }
+
+  out
+}
+
+#' Visualize annual mean of mosaicked outputs
+#'
+#' Displays the annual mean of the selected variables in a multi panel plot.
+#'
+#' @inheritParams load_mosaic_annual_means
+#' @return Invisibly returns the list of rasters used for plotting.
+#' @examples
+#' visualize_mosaic_outputs("domain_chile/OUT", roi_file = "roi.shp")
+#' @export
+visualize_mosaic_outputs <- function(out_dir, vars = NULL, roi_file = NULL) {
+  rasters <- load_mosaic_annual_means(out_dir, vars, roi_file)
+  vars <- names(rasters)
+  n <- length(rasters)
+  ncol <- ceiling(sqrt(n))
+  nrow <- ceiling(n / ncol)
+
+  op <- par(no.readonly = TRUE)
+  on.exit(par(op))
+  par(mfrow = c(nrow, ncol), mar = c(4, 4, 2, 5))
+
+  for (v in vars) {
+    plot(rasters[[v]], main = v)
+  }
+
+  invisible(rasters)
+}

--- a/README.html
+++ b/README.html
@@ -370,6 +370,7 @@ configuración.</p>
 mensuales o anuales a TIFF o NetCDF desde
 <code>mHM_Fluxes_States.nc</code>. El resultado es un único archivo con
 una banda por cada periodo de tiempo solicitado.</p>
+<p>Para visualizar promedios anuales de los mosaicos resultantes se puede emplear el script <a href="R/visualize_mosaic_outputs.R"><code>R/visualize_mosaic_outputs.R</code></a>, el cual permite definir un archivo ROI para enmascarar las salidas.</p>
 <p>Para visualizar promedios anuales de las salidas y forzantes del
 modelo se incluye el script <a href="R/visualize_annual_outputs.R"><code>R/visualize_annual_outputs.R</code></a>
 que provee las funciones <code>annual_mean</code> y

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Para visualizar promedios anuales de largo plazo de las salidas y forzantes del 
 En [`R/utils.R`](R/utils.R) se encuentran algunas funciones utiles para la ejecucion del pre y post procesamiento.
 
 La función `write_output` permite exportar variables mensuales o anuales a TIFF o NetCDF desde el output del modelo `mHM_Fluxes_States.nc`. El resultado es un único archivo con una banda por cada periodo de tiempo solicitado.
+
+Para visualizar promedios anuales de los archivos mosaiceados se puede utilizar el script [`R/visualize_mosaic_outputs.R`](R/visualize_mosaic_outputs.R). Este script permite seleccionar un archivo de ROI para enmascarar los resultados.


### PR DESCRIPTION
## Summary
- add `visualize_mosaic_outputs.R` with functions to load and plot annual means from mosaicked NetCDF files
- document new script in README

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684882f41cb4832c8ad85565c1a14b5b