### PR TITLE
Add mosaic full visualization helper

### DIFF
--- a/R/mosaic_outputs.R
+++ b/R/mosaic_outputs.R
@@ -187,3 +187,57 @@ visualize_meteo_mosaic <- function(domains = NULL,
   invisible(mosaics)
 }
 
+#' Load annual mean forcings across multiple domains
+#'
+#' Reads daily meteorological NetCDF files from each domain, masks them with the
+#' ROI specified in `preprocess_config.json`, aggregates to monthly and then to
+#' long term annual mean, and finally mosaics the domains.
+#'
+#' @param domains Character vector with paths to the domain folders. Defaults to
+#'   `dir(pattern = "domain_zone", full.names = TRUE)`.
+#' @param vars Character vector of forcing names to load.
+#' @return A named list of [`terra::SpatRaster`] objects containing the annual
+#'   mean of each variable.
+#' @noRd
+load_meteo_mosaic_annual_means <- function(domains = dir(pattern = "domain_zone", full.names = TRUE),
+                                           vars) {
+  library(terra)
+  library(jsonlite)
+
+  if (length(domains) == 0) {
+    stop("No domain folders found")
+  }
+  if (missing(vars)) {
+    stop("'vars' must be provided")
+  }
+
+  fun_map <- c(pre = "sum", pet = "sum", tmin = "mean", tmax = "mean", tavg = "mean")
+  out <- vector("list", length(vars))
+  names(out) <- vars
+
+  for (v in vars) {
+    rasters <- list()
+    for (d in domains) {
+      cfg_path <- file.path(d, "preprocess_config.json")
+      if (!file.exists(cfg_path)) {
+        stop("Configuration file not found in ", d)
+      }
+      cfg <- fromJSON(cfg_path)
+      meteo_file <- file.path(d, "meteo", paste0(v, ".nc"))
+      if (!file.exists(meteo_file)) {
+        stop("NetCDF file not found: ", meteo_file)
+      }
+      r <- rast(meteo_file, subds = v)
+      if (!is.null(cfg$roi_file) && file.exists(cfg$roi_file)) {
+        roi <- vect(cfg$roi_file)
+        r <- mask(r, roi)
+      }
+      r_month <- daily_to_monthly(r, fun = fun_map[[v]])
+      r_ann <- annual_mean(r_month, fun = fun_map[[v]])
+      rasters[[length(rasters) + 1]] <- r_ann
+    }
+    out[[v]] <- do.call(mosaic, rasters)
+  }
+
+  out
+}

--- a/R/visualize_mosaic_outputs.R
+++ b/R/visualize_mosaic_outputs.R
@@ -78,3 +78,62 @@ visualize_mosaic_outputs <- function(out_dir, vars = NULL, roi_file = NULL) {
 
   invisible(rasters)
 }
+
+#' Visualize mosaicked model outputs and forcings
+#'
+#' Combines annual mean forcings from multiple domains with the mosaicked model
+#' outputs produced by `mosaic_outputs()` and displays them using the same 2x5
+#' layout as `visualize_annual_outputs()`.
+#'
+#' @param out_dir Directory containing the mosaicked model NetCDF files.
+#' @param domains Character vector with paths to the domain folders used to load
+#'   the meteorological forcings. Defaults to
+#'   `dir(pattern = "domain_zone", full.names = TRUE)`.
+#' @param roi_file Optional ROI used to mask the model outputs.
+#' @param vars Character vector of model output variables to visualize. Defaults
+#'   to `c("snowpack", "SM_Lall", "satSTW", "aET", "Q")`.
+#' @return Invisibly returns the list of rasters used for plotting.
+#' @examples
+#' domain_folders <- dir(pattern = "domain_zone", full.names = TRUE)
+#' visualize_mosaic_full_outputs(out_dir = "domain_chile/OUT",
+#'                               domains = domain_folders)
+#' @export
+visualize_mosaic_full_outputs <- function(out_dir,
+                                          domains = dir(pattern = "domain_zone", full.names = TRUE),
+                                          roi_file = NULL,
+                                          vars = c("snowpack", "SM_Lall", "satSTW", "aET", "Q")) {
+  library(terra)
+
+  mod <- load_mosaic_annual_means(out_dir, vars, roi_file)
+  met <- load_meteo_mosaic_annual_means(domains, c("pre", "pet"))
+
+  pre_ann <- met[["pre"]]
+  pet_ann <- met[["pet"]]
+  aet_ann <- mod[["aET"]]
+  q_ann   <- mod[["Q"]]
+  sm_ann  <- mod[["SM_Lall"]]
+  snow_ann <- mod[["snowpack"]]
+  sat_ann <- mod[["satSTW"]]
+
+  disp_ann <- pre_ann - aet_ann
+
+  flux_range <- range(c(values(pre_ann), values(pet_ann), values(aet_ann), values(q_ann)), na.rm = TRUE)
+  state_range <- range(c(values(snow_ann), values(sm_ann), values(sat_ann)), na.rm = TRUE)
+
+  op <- par(no.readonly = TRUE)
+  on.exit(par(op))
+  par(mfrow = c(2, 5), mar = c(4, 4, 2, 5))
+
+  plot(pre_ann, main = "Pre", zlim = flux_range)
+  plot(pet_ann, main = "Pet", zlim = flux_range)
+  plot(aet_ann, main = "aET", zlim = flux_range)
+  plot(q_ann, main = "Q", zlim = flux_range)
+  plot(disp_ann, main = "Pr-ET", zlim = flux_range)
+
+  plot(sm_ann, main = "SM_Lall", zlim = state_range)
+  plot(snow_ann, main = "snowpack", zlim = state_range)
+  plot(sat_ann, main = "satSTW", zlim = state_range)
+  plot.new()
+
+  invisible(c(met, mod))
+}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ En [`R/utils.R`](R/utils.R) se encuentran algunas funciones utiles para la ejecu
 La función `write_output` permite exportar variables mensuales o anuales a TIFF o NetCDF desde el output del modelo `mHM_Fluxes_States.nc`. El resultado es un único archivo con una banda por cada periodo de tiempo solicitado.
 
 Para visualizar promedios anuales de los archivos mosaiceados se puede utilizar el script [`R/visualize_mosaic_outputs.R`](R/visualize_mosaic_outputs.R). Este script permite seleccionar un archivo de ROI para enmascarar los resultados.
+
+Para visualizar conjuntamente las salidas mosaiceadas y las forzantes se puede utilizar:
+
+```r
+domain_folders <- dir(pattern = "domain_zone", full.names = TRUE)
+visualize_mosaic_full_outputs(out_dir = "domain_chile/OUT",
+                              domains = domain_folders)
+```


### PR DESCRIPTION
## Summary
- add `load_meteo_mosaic_annual_means()` helper for daily meteo mosaics
- add `visualize_mosaic_full_outputs()` to plot mosaicked outputs and forcings
- document example usage in README

## Testing
- `Rscript -e "source('R/utils.R'); source('R/mosaic_outputs.R'); source('R/visualize_mosaic_outputs.R');"`

------
https://chatgpt.com/codex/tasks/task_e_6848a5a64d70832c9d505ff89c929af5