### PR TITLE
Add custom ROI option for visualize_annual_outputs

### DIFF
--- a/README.html
+++ b/README.html
@@ -365,7 +365,8 @@ Las funciones auxiliares <code>annual_mean</code>,
 encuentran en <a href="R/utils.R"><code>R/utils.R</code></a>.
 <code>visualize_annual_outputs</code> puede opcionalmente enmascarar los
 resultados usando el <code>roi_file</code> definido en el archivo de
-configuración.</p>
+configuración o un archivo entregado mediante el argumento
+<code>roi_file</code>.</p>
 <p>La función <code>write_output</code> permite exportar variables
 mensuales o anuales a TIFF o NetCDF desde
 <code>mHM_Fluxes_States.nc</code>. El resultado es un único archivo con

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Este repositorio contiene utilidades en R y Python para preparar los datos de en
 
 Para una explicación detallada de cómo ejecutar el script principal de preprocesamiento consulte [run_preprocessing.md](run_preprocessing.md).
 
-Para visualizar promedios anuales de largo plazo de las salidas y forzantes del modelo se incluye el script [`R/visualize_annual_outputs.R`](R/visualize_annual_outputs.R). 
+Para visualizar promedios anuales de largo plazo de las salidas y forzantes del modelo se incluye el script [`R/visualize_annual_outputs.R`](R/visualize_annual_outputs.R).
+
+La función `visualize_annual_outputs` permite opcionalmente entregar la ruta de un archivo ROI mediante el argumento `roi_file` para recortar y enmascarar los resultados a dicha zona en lugar de utilizar el ROI definido en la configuración.
 
 En [`R/utils.R`](R/utils.R) se encuentran algunas funciones utiles para la ejecucion del pre y post procesamiento.
 


### PR DESCRIPTION
## Summary
- add `roi_file` parameter to `visualize_annual_outputs`
- allow cropping/masking to custom ROI
- document new option in README files

## Testing
- `Rscript -e "source('R/utils.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850307cd974832c8a9fdf8dad293bb1