### PR TITLE
Add config_name parameter for custom configs

### DIFF
--- a/R/preprocess/preprocess_forcings.R
+++ b/R/preprocess/preprocess_forcings.R
@@ -30,7 +30,8 @@ preprocess_climate_data <- function(domain_path, remove_temp = TRUE,
                                     prec = "double",
                                     fix.negatives = FALSE,
                                     iter_num = 3,
-                                    crop_to_roi = TRUE) {
+                                    crop_to_roi = TRUE,
+                                    config_name = "preprocess_config.yaml") {
   library(yaml)
   library(terra)
   library(sf)
@@ -114,7 +115,7 @@ preprocess_climate_data <- function(domain_path, remove_temp = TRUE,
   }
   
   # Load config
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   roi_path <- config$roi_file
@@ -260,7 +261,8 @@ preprocess_climate_data <- function(domain_path, remove_temp = TRUE,
 #' @examples
 #' preprocess_LAI_data("/path/to/domain")
 preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
-                               crop_to_roi = TRUE, force.fill = FALSE){
+                               crop_to_roi = TRUE, force.fill = FALSE,
+                               config_name = "preprocess_config.yaml"){
   library(terra)
   library(sf)
   library(yaml)
@@ -268,7 +270,7 @@ preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
   # source("scripts/R/utils.R")
   
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   lai_path <- config$lai_file
@@ -351,7 +353,8 @@ preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
 #' @examples
 #' preprocess_dem_data("/path/to/domain")
 preprocess_dem_data<- function(domain_path, remove_temp = FALSE,
-                               crop_to_roi = TRUE) {
+                               crop_to_roi = TRUE,
+                               config_name = "preprocess_config.yaml") {
   library(tidyverse)
   library(terra)
   library(sf)
@@ -359,7 +362,7 @@ preprocess_dem_data<- function(domain_path, remove_temp = FALSE,
   library(whitebox)
   
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- yaml::read_yaml(config_path)
   
   ref_file <- file.path(domain_path, config$meteo_folder, "pre.nc")
@@ -457,13 +460,14 @@ preprocess_dem_data<- function(domain_path, remove_temp = FALSE,
 #' @examples
 #' preprocess_lc_data("/path/to/domain")
 preprocess_lc_data = function(domain_path, remove_temp = FALSE,
-                              crop_to_roi = TRUE){
+                              crop_to_roi = TRUE,
+                              config_name = "preprocess_config.yaml"){
   library(tidyverse)
   library(terra)
   library(sf)
   library(yaml)
   # leer archivo de configuracion json con rutas de archivos
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   # Paths from config
@@ -555,7 +559,8 @@ preprocess_lc_data = function(domain_path, remove_temp = FALSE,
 #' @examples
 #' preprocess_geo_data("/path/to/domain")
 preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = "local",
-                               crop_to_roi = TRUE) {
+                               crop_to_roi = TRUE,
+                               config_name = "preprocess_config.yaml") {
   library(tidyverse)
   library(terra)
   library(sf)
@@ -563,7 +568,7 @@ preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = 
   
   sf_use_s2(FALSE)
   # leer archivo de configuracion json con rutas de archivos
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   geo_file <- config$geo_file
@@ -709,13 +714,14 @@ preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = 
 #' @examples
 #' preprocess_soil_data("/path/to/domain")
 preprocess_soil_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
-                               crop_to_roi = TRUE){
+                               crop_to_roi = TRUE,
+                               config_name = "preprocess_config.yaml"){
   library(tidyverse)
   library(terra)
   library(sf)
   library(yaml)
   
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   roi_file = config$roi_file
@@ -902,11 +908,12 @@ preprocess_soil_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
 #'
 #' @examples
 #' create_roi_mask("/path/to/domain/preprocess_config.yaml")
-create_roi_mask = function(config_path, remove_temp = FALSE, basin.mask = FALSE){
+create_roi_mask = function(domain_path, config_name = "preprocess_config.yaml",
+                          remove_temp = FALSE, basin.mask = FALSE){
   library(terra)
   library(yaml)
-  
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   morph_folder = file.path(domain_path, config$morph_folder)
   lc_folder = file.path(domain_path, config$lc_folder)
@@ -982,7 +989,8 @@ create_roi_mask = function(config_path, remove_temp = FALSE, basin.mask = FALSE)
 #' @examples
 #' preprocess_streamflow_data("/path/to/domain")
 preprocess_streamflow_data = function(domain_path, remove_temp = FALSE,
-                                      crop_to_roi = TRUE){
+                                      crop_to_roi = TRUE,
+                                      config_name = "preprocess_config.yaml"){
   library(yaml)
   library(lubridate)
   library(tidyverse)
@@ -990,7 +998,7 @@ preprocess_streamflow_data = function(domain_path, remove_temp = FALSE,
   sf_use_s2(FALSE)
   
   # === Load configuration ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   streamflow_data_file = config$streamflow_data_file
@@ -1082,14 +1090,15 @@ preprocess_streamflow_data = function(domain_path, remove_temp = FALSE,
 #'
 #' @examples
 #' create_idgauges("/path/to/domain")
-create_idgauges = function(domain_path, remove_temp = FALSE){
+create_idgauges = function(domain_path, remove_temp = FALSE,
+                           config_name = "preprocess_config.yaml"){
   library(sf)
   library(terra)
   library(readr)
   library(yaml)
   # browser()
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   gauge_file <- config$fluv_station_file

--- a/R/preprocess/preprocess_forcings_bigdata.R
+++ b/R/preprocess/preprocess_forcings_bigdata.R
@@ -1,4 +1,5 @@
-preprocess_climate_data <- function(domain_path, remove_temp = TRUE) {
+preprocess_climate_data <- function(domain_path, remove_temp = TRUE,
+                                    config_name = "preprocess_config.yaml") {
   library(yaml)
   library(terra)
   library(sf)
@@ -65,7 +66,7 @@ preprocess_climate_data <- function(domain_path, remove_temp = TRUE) {
     cat("✅ NetCDF successfully written to:", filename, "\n")
   }
   # Load config
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   roi_path <- config$roi_file
@@ -160,7 +161,8 @@ preprocess_climate_data <- function(domain_path, remove_temp = TRUE) {
   }
 }
 
-preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10){
+preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10,
+                               config_name = "preprocess_config.yaml"){
   library(terra)
   library(sf)
   library(yaml)
@@ -168,7 +170,7 @@ preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10){
   # source("scripts/R/utils.R")
   
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   lai_path <- config$lai_file
@@ -231,7 +233,8 @@ preprocess_LAI_data = function(domain_path, remove_temp = FALSE, iter_num = 10){
   }
 }
 
-preprocess_dem_data<- function(domain_path, remove_temp = FALSE) {
+preprocess_dem_data<- function(domain_path, remove_temp = FALSE,
+                               config_name = "preprocess_config.yaml") {
   library(tidyverse)
   library(terra)
   library(sf)
@@ -239,7 +242,7 @@ preprocess_dem_data<- function(domain_path, remove_temp = FALSE) {
   library(whitebox)
   
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- yaml::read_yaml(config_path)
   
   ref_file <- file.path(domain_path, config$meteo_folder, "pre.nc")
@@ -324,13 +327,14 @@ preprocess_dem_data<- function(domain_path, remove_temp = FALSE) {
   }
 }
 
-preprocess_lc_data = function(domain_path, remove_temp = FALSE){
+preprocess_lc_data = function(domain_path, remove_temp = FALSE,
+                              config_name = "preprocess_config.yaml"){
   library(tidyverse)
   library(terra)
   library(sf)
   library(yaml)
   # leer archivo de configuracion json con rutas de archivos
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   # Paths from config
@@ -406,13 +410,14 @@ preprocess_lc_data = function(domain_path, remove_temp = FALSE){
 }
 
 
-preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = "local") {
+preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = "local",
+                               config_name = "preprocess_config.yaml") {
   library(tidyverse)
   library(terra)
   library(sf)
   library(yaml)
   # leer archivo de configuracion json con rutas de archivos
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   geo_file <- config$geo_file
@@ -540,13 +545,14 @@ preprocess_geo_data <- function(domain_path, remove_temp = FALSE, source.file = 
   }
 }
 
-preprocess_soil_data = function(domain_path, remove_temp = FALSE){
+preprocess_soil_data = function(domain_path, remove_temp = FALSE,
+                               config_name = "preprocess_config.yaml"){
   library(tidyverse)
   library(terra)
   library(sf)
   library(yaml)
   
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config_path = "preprocess_config_windows.json"
   config <- read_yaml(config_path)
   
@@ -723,11 +729,12 @@ preprocess_soil_data = function(domain_path, remove_temp = FALSE){
   }
 }
 
-create_roi_mask = function(config_path, remove_temp = FALSE, basin.mask = FALSE){
+create_roi_mask = function(domain_path, config_name = "preprocess_config.yaml",
+                          remove_temp = FALSE, basin.mask = FALSE){
   library(terra)
   library(yaml)
   
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   morph_folder = file.path(domain_path, config$morph_folder)
   lc_folder = file.path(domain_path, config$lc_folder)
@@ -792,13 +799,14 @@ create_roi_mask = function(config_path, remove_temp = FALSE, basin.mask = FALSE)
 }
 
 
-preprocess_streamflow_data = function(domain_path, remove_temp = FALSE){
+preprocess_streamflow_data = function(domain_path, remove_temp = FALSE,
+                                      config_name = "preprocess_config.yaml"){
   library(yaml)
   library(lubridate)
   library(tidyverse)
   
   # === Load configuration ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   gauges_file = config$fluv_station_file
@@ -869,14 +877,15 @@ preprocess_streamflow_data = function(domain_path, remove_temp = FALSE){
   }
 }
 
-create_idgauges = function(domain_path, remove_temp = FALSE){
+create_idgauges = function(domain_path, remove_temp = FALSE,
+                           config_name = "preprocess_config.yaml"){
   library(sf)
   library(terra)
   library(readr)
   library(yaml)
   
   # === Load config ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   gauge_file <- config$fluv_station_file

--- a/R/utils.R
+++ b/R/utils.R
@@ -288,7 +288,8 @@ extract_roi_timeseries_all <- function(nc_path, roi_file, out_file = NULL) {
 mosaic_outputs <- function(domains = NULL,
                            out_dir = "domain_chile/OUT",
                            vars = c("snowpack","SM_Lall","satSTW","aET","Q",
-                                    "SM_L01","SM_L02","SM_L03","SM_L04","SM_L05","SM_L06")) {
+                                    "SM_L01","SM_L02","SM_L03","SM_L04","SM_L05","SM_L06"),
+                           config_name = "preprocess_config.yaml") {
   library(terra)
   library(yaml)
   
@@ -306,7 +307,7 @@ mosaic_outputs <- function(domains = NULL,
     message("Mosaicking variable: ", v)
     rasters <- list()
     for (d in domains) {
-      cfg_path <- file.path(d, "preprocess_config.yaml")
+      cfg_path <- file.path(d, config_name)
       if (!file.exists(cfg_path)) {
         stop("Configuration file not found in ", d)
       }
@@ -350,7 +351,8 @@ mosaic_outputs <- function(domains = NULL,
 #' @export
 mosaic_meteo <- function(domains = NULL,
                          out_dir = "domain_chile/OUT",
-                         vars = c("pre", "pet", "tmin", "tmax", "tavg")) {
+                         vars = c("pre", "pet", "tmin", "tmax", "tavg"),
+                         config_name = "preprocess_config.yaml") {
   library(terra)
   library(yaml)
   
@@ -368,7 +370,7 @@ mosaic_meteo <- function(domains = NULL,
     message("Mosaicking variable: ", v)
     rasters <- list()
     for (d in domains) {
-      cfg_path <- file.path(d, "preprocess_config.yaml")
+      cfg_path <- file.path(d, config_name)
       if (!file.exists(cfg_path)) {
         stop("Configuration file not found in ", d)
       }
@@ -417,14 +419,15 @@ mosaic_meteo <- function(domains = NULL,
 #' @export
 write_output <- function(domain_path, var_name, ts,
                          roi_mask = TRUE, roi_file = NULL,
-                         out.format = c("tif", "nc"), out.opt = NULL) {
+                         out.format = c("tif", "nc"), out.opt = NULL,
+                         config_name = "preprocess_config.yaml") {
   library(terra)
   library(yaml)
   
   out.format <- match.arg(out.format)
   ts <- match.arg(tolower(ts), c("month", "year"))
   
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   if (!file.exists(config_path)) {
     stop("Configuration file not found: ", config_path)
   }
@@ -494,8 +497,9 @@ write_output <- function(domain_path, var_name, ts,
 #'   defaults to "/Volumes/KINGSTON/FONDECYT_CAMILA/mHM_CL/FIGS".
 #' @export
 visualize_annual_outputs <- function(domain_path, mask_roi = FALSE,
-                                     roi_file = NULL, filename = NULL, 
-                                     out_folder = NULL, res_folder = NULL) {
+                                     roi_file = NULL, filename = NULL,
+                                     out_folder = NULL, res_folder = NULL,
+                                     config_name = "preprocess_config.yaml") {
   library(terra)
   library(yaml)
   
@@ -516,7 +520,7 @@ visualize_annual_outputs <- function(domain_path, mask_roi = FALSE,
     }
     roi <- vect(roi_file)
   } else if (mask_roi) {
-    config_path <- file.path(domain_path, "preprocess_config.yaml")
+    config_path <- file.path(domain_path, config_name)
     if (!file.exists(config_path)) {
       stop("Configuration file not found: ", config_path)
     }
@@ -729,14 +733,15 @@ plot_raster <- function(r, var, limits, palette = 16) {
 #'
 #' @return A tibble with columns `ID`, `date`, `Q_sim` and `Q_obs`.
 #' @export
-get_qmm_table <- function(domain_path, crop_to_roi = TRUE) {
+get_qmm_table <- function(domain_path, crop_to_roi = TRUE,
+                          config_name = "preprocess_config.yaml") {
   library(terra)
   library(sf)
   library(yaml)
   library(tidyverse)
   # browser()
   # === Load config and paths ===
-  config_path <- file.path(domain_path, "preprocess_config.yaml")
+  config_path <- file.path(domain_path, config_name)
   config <- read_yaml(config_path)
   
   streamflow_data_file <- config$streamflow_data_file_mm

--- a/python/calibrate_model_option.py
+++ b/python/calibrate_model_option.py
@@ -10,14 +10,14 @@ import yaml
 import shutil
 import f90nml
 
-def update_calibrate_option(domain_path):
+def update_calibrate_option(domain_path, config_name="preprocess_config.yaml"):
     """
     Rewrites the &mainconfig_mhm_mrm section in mhm.nml using values from preprocess_config.yaml,
     including a dynamic 'optimize' value based on the 'calibrate_model' key in the config file.
     """
 
     # Paths
-    config_path = os.path.join(domain_path, 'preprocess_config.yaml')
+    config_path = os.path.join(domain_path, config_name)
     exe_path = os.path.join(domain_path, 'exe')
     nml_path = os.path.join(exe_path, 'mhm.nml')
     temp_dir = os.path.join(exe_path, 'temp')

--- a/python/create_geoparameter_block.py
+++ b/python/create_geoparameter_block.py
@@ -3,7 +3,7 @@ import os
 import yaml
 import re
 
-def write_geoparam_block(domain_path):
+def write_geoparam_block(domain_path, config_name="preprocess_config.yaml"):
     """Create a GeoParam block from geology definitions and write it to disk.
 
     Parameters
@@ -20,7 +20,7 @@ def write_geoparam_block(domain_path):
     """
 
     # === Load config to get folders ===
-    config_path = os.path.join(domain_path, "preprocess_config.yaml")
+    config_path = os.path.join(domain_path, config_name)
 
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)

--- a/python/modify_parameters_with_geoblock.py
+++ b/python/modify_parameters_with_geoblock.py
@@ -11,7 +11,7 @@ import os
 import re
 import yaml
 
-def update_geoparam_block(domain_path):
+def update_geoparam_block(domain_path, config_name="preprocess_config.yaml"):
     """Replace the &geoparameter block in ``mhm_parameter.nml``.
 
     Parameters
@@ -28,7 +28,7 @@ def update_geoparam_block(domain_path):
     """
 
     # === Load config ===
-    config_path = os.path.join(domain_path, "preprocess_config.yaml")
+    config_path = os.path.join(domain_path, config_name)
 
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)

--- a/python/update_nml_gauges.py
+++ b/python/update_nml_gauges.py
@@ -11,7 +11,7 @@ import f90nml
 import yaml
 import shutil
 
-def update_evaluation_gauges(domain_path):
+def update_evaluation_gauges(domain_path, config_name="preprocess_config.yaml"):
     """Update the evaluation gauge list inside ``mhm.nml`` for a domain.
 
     Parameters
@@ -27,7 +27,7 @@ def update_evaluation_gauges(domain_path):
         and saves a backup of the original file.
     """
 
-    config_path = os.path.join(domain_path, "preprocess_config.yaml")
+    config_path = os.path.join(domain_path, config_name)
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 

--- a/python/update_time_periods.py
+++ b/python/update_time_periods.py
@@ -4,7 +4,7 @@ import shutil
 import f90nml
 from dateutil import parser as date_parser
 
-def update_time_periods(domain_path):
+def update_time_periods(domain_path, config_name="preprocess_config.yaml"):
     """
     Updates the &time_periods section in the mhm.nml file based on the start_date and end_date
     specified in the preprocess_config.yaml file located in the domain_path.
@@ -14,7 +14,7 @@ def update_time_periods(domain_path):
     """
 
     # Paths
-    config_path = os.path.join(domain_path, 'preprocess_config.yaml')
+    config_path = os.path.join(domain_path, config_name)
     exe_path = os.path.join(domain_path, 'exe')
     nml_path = os.path.join(exe_path, 'mhm.nml')
     temp_dir = os.path.join(exe_path, 'temp')


### PR DESCRIPTION
## Summary
- allow specifying custom config name in R preprocessing functions
- update big data preprocessing functions for custom config name
- enable config_name option in utility helpers
- let Python scripts accept a custom config file name

## Testing
- `python -m py_compile python/modify_parameters_with_geoblock.py python/update_nml_gauges.py python/update_time_periods.py python/calibrate_model_option.py python/create_geoparameter_block.py`
- `Rscript` not available so R code was not executed

------
https://chatgpt.com/codex/tasks/task_e_68758871f7fc832cbdc8a764b2222b8f