### PR TITLE
Add dynamic file selection for Shiny app

### DIFF
--- a/visual_annual_mean/app.R
+++ b/visual_annual_mean/app.R
@@ -1,0 +1,90 @@
+#' Shiny application integrating raster navigation, coordinate selection and
+#' time series visualization modules.
+#'
+#' Allows users to dynamically choose raster files and a NetCDF file,
+#' navigate through the rasters, select coordinates either from a CSV file or
+#' manual entry, extract a time series at the chosen point and visualise it
+#' interactively.
+#'
+#' The application assumes all spatial data use EPSG:4326.
+#'
+#' Run with `shiny::runApp()`.
+
+# Load required packages ---------------------------------------------------
+library(shiny)
+library(leaflet)
+library(sf)
+library(terra)
+library(plotly)
+library(ggplot2)
+library(dplyr)
+
+# Source modules and helper function --------------------------------------
+source("visual_annual_mean/raster_navigation_module.R")
+source("visual_annual_mean/coordinate_selector_module.R")
+source("visual_annual_mean/extract_timeseries.R")
+source("visual_annual_mean/timeseries_plot_module.R")
+
+
+# UI ----------------------------------------------------------------------
+ui <- fluidPage(
+  titlePanel("Raster visualisation and time series extraction"),
+  fluidRow(
+    column(6,
+           fileInput("raster_files", "Select raster files",
+                     multiple = TRUE,
+                     accept = c(".tif", ".nc")),
+           fileInput("nc_file", "Select NetCDF file", accept = ".nc")
+    )
+  ),
+  fluidRow(
+    column(6,
+           raster_navigation_ui("raster_nav")
+    ),
+    column(6,
+           coordinate_selector_ui("coords")
+    )
+  ),
+  hr(),
+  timeseries_plot_ui("ts_plot")
+)
+
+# Server ------------------------------------------------------------------
+server <- function(input, output, session) {
+
+  raster_files_react <- reactive({
+    if (is.null(input$raster_files)) character(0) else input$raster_files$datapath
+  })
+
+  nc_file_react <- reactive({
+    req(input$nc_file)
+    input$nc_file$datapath
+  })
+
+  # Initialise modules -----------------------------------------------------
+  raster_react <- raster_navigation_server("raster_nav", raster_files_react)
+  coords_react <- coordinate_selector_server("coords")
+
+  # Overlay selected points on raster map ---------------------------------
+  observe({
+    pts <- coords_react()
+    proxy <- leafletProxy("raster_nav-map")
+    proxy %>% clearMarkers()
+    if (nrow(pts) > 0) {
+      xy <- st_coordinates(pts)
+      proxy %>% addCircleMarkers(lng = xy[,1], lat = xy[,2], color = "red")
+    }
+  })
+
+  # Extract time series at first selected point ---------------------------
+  ts_data <- reactive({
+    pts <- coords_react()
+    req(nrow(pts) > 0, nc_file_react())
+    extract_timeseries_at_point(pts[1, ], nc_file_react())
+  })
+
+  timeseries_plot_server("ts_plot", ts_data)
+}
+
+# Run the application -----------------------------------------------------
+shinyApp(ui, server)

--- a/visual_annual_mean/raster_navigation_module.R
+++ b/visual_annual_mean/raster_navigation_module.R
@@ -28,24 +28,32 @@ raster_navigation_ui <- function(id) {
 #'
 #' @param id Module ID.
 #' @param raster_files Character vector with paths to raster files (`.tif` or
-#'   `.nc`).
+#'   `.nc`) or a reactive expression returning such a vector. The list can be
+#'   updated dynamically.
 #'
 #' @return A list with reactive elements `raster` and `index`.
 #' @export
 raster_navigation_server <- function(id, raster_files) {
   moduleServer(id, function(input, output, session) {
-    n <- length(raster_files)
+    files <- if (shiny::is.reactive(raster_files)) raster_files else shiny::reactive(raster_files)
     idx <- reactiveVal(1)
+
+    n_files <- reactive({ length(files()) })
+
+    observeEvent(files(), {
+      idx(1)
+    }, ignoreNULL = TRUE)
 
     observeEvent(input$prev, {
       if (idx() > 1) idx(idx() - 1)
     })
     observeEvent(input$next, {
-      if (idx() < n) idx(idx() + 1)
+      if (idx() < n_files()) idx(idx() + 1)
     })
 
     current_raster <- reactive({
-      r <- terra::rast(raster_files[idx()])
+      req(n_files() > 0)
+      r <- terra::rast(files()[idx()])
       terra::project(r, "EPSG:4326")
     })
 
@@ -61,7 +69,12 @@ raster_navigation_server <- function(id, raster_files) {
     })
 
     output$counter <- shiny::renderText({
-      sprintf("Raster %d de %d", idx(), n)
+      n <- n_files()
+      if (n == 0) {
+        "No rasters selected"
+      } else {
+        sprintf("Raster %d de %d", idx(), n)
+      }
     })
 
     list(raster = current_raster, index = idx)


### PR DESCRIPTION
## Summary
- update raster navigation module to accept reactive file lists
- allow users to pick raster and NetCDF files in the app

## Testing
- `R -q -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878954e4308832c901445df5d3e26ae