### PR TITLE
Add postprocess workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Este repositorio contiene utilidades en R y Python para preparar los datos de entrada del modelo hidrológico distribuido mHM.
 
 Para una explicación detallada de cómo ejecutar el script principal de preprocesamiento consulte [run_preprocessing.md](run_preprocessing.md).
+Para revisar el flujo de postprocesamiento y generación de figuras consulte [postprocess_workflow.md](postprocess_workflow.md).
 
 Para visualizar promedios anuales de largo plazo de las salidas y forzantes del modelo se incluye el script [`R/visualize_annual_outputs.R`](R/visualize_annual_outputs.R).
 

--- a/postprocess_workflow.md
+++ b/postprocess_workflow.md
@@ -1,0 +1,35 @@
+# Documentación de `postprocess_workflow.R`
+
+Este documento explica el flujo básico de postprocesamiento de las salidas generadas por mHM. El script `postprocess_workflow.R` emplea funciones de [`R/utils.R`](R/utils.R) para generar archivos listos para su análisis.
+
+## Requisitos previos
+
+- Haber completado el preprocesamiento del dominio y contar con las salidas de mHM.
+- Disponer de las librerías de R usadas en el script (`terra`, `tidyverse`, `stars`, `sf`, `yaml`).
+
+## Uso básico
+
+1. Ajuste `domain_path` y `config_name` al comienzo del script para apuntar al dominio y al archivo de configuración.
+2. Ejecute desde R:
+
+```R
+source("R/postprocess_workflow.R")
+```
+
+Se creará la carpeta `FIGS/` en caso de no existir y se escribirán allí las figuras generadas.
+
+## Tareas realizadas
+
+- **write_output**: exporta variables mensuales desde `mHM_Fluxes_States.nc` recortando al ROI definido en la configuración.
+- **write_clim**: procesa las forzantes meteorológicas a resolución mensual.
+- **calculate_annual_mean** y **visualize_annual_mean**: calculan promedios anuales y guardan una imagen resumen.
+- **get_qmm_table** y **get_qm3s_table**: extraen series de caudal en milímetros y metros cúbicos por segundo.
+- Combina ambas tablas en `streamflow/streamflow_data.csv` dentro de la carpeta `OUT`.
+
+## Salidas generadas
+
+- Archivos NetCDF mensuales en `OUT`.
+- Gráficos en `FIGS/annual_output_default.png`.
+- Tabla de caudal observada y simulada en `OUT/streamflow/`.
+
+Estas utilidades permiten analizar rápidamente tanto las forzantes como las salidas del modelo.


### PR DESCRIPTION
## Summary
- document postprocess workflow in a new markdown file
- link the new documentation from the README for easy reference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892cebefd0832cb5bc3405f2c08f00