### PR TITLE
Update .gitignore for macOS hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,7 @@ __pycache__/
 *.pyc
 .DS_Store
 **/._*
+# macOS hidden files
+.*
+_*
 


### PR DESCRIPTION
## Summary
- ignore hidden dot or underscore-prefixed files

## Testing
- `python3 -m py_compile $(git ls-files 'python/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68892d21213c832cbfbf148f9f6595a7